### PR TITLE
Add FastNoise

### DIFF
--- a/engine-tests/src/test/java/org/terasology/utilities/FastNoiseTest.java
+++ b/engine-tests/src/test/java/org/terasology/utilities/FastNoiseTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.utilities;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.terasology.utilities.procedural.FastNoise;
+import org.terasology.utilities.random.FastRandom;
+
+/**
+ * A simple validity test for {@link FastNoise}
+ *
+ * @author Martin Steiger
+ */
+public class FastNoiseTest {
+
+    @Test
+    public void distributionTest() {
+        FastRandom rng = new FastRandom(0xBEEF);
+        FastNoise noiseGen = new FastNoise(0xDEADC0DE);
+
+        int count = 1000000;
+        int bucketCount = 20;
+        int[] buckets = new int[bucketCount];
+
+        for (int i = 0; i < count; i++) {
+            float posX = rng.nextFloat() * 100f;
+            float posY = rng.nextFloat() * 100f;
+            float posZ = rng.nextFloat() * 100f;
+
+            float noise = noiseGen.noise(posX, posY, posZ);
+            int idx = (int) (noise * bucketCount);
+            if (idx == bucketCount) {
+                idx = bucketCount - 1;
+            }
+            buckets[idx]++;
+        }
+
+        float avg = count / bucketCount;
+
+        for (int i = 0; i < bucketCount; i++) {
+            float val = Math.abs((buckets[i] - avg) / avg);
+            // less than 5% deviation from the expected average
+            Assert.assertTrue(val < 0.05);
+        }
+    }
+
+    @Test
+    public void resolutionTest() {
+        FastRandom rng = new FastRandom(0xBEEF);
+        FastNoise noiseGen = new FastNoise(0xDEADC0DE);
+
+        int count = 1000000;
+
+        for (int i = 0; i < count; i++) {
+            float posX = rng.nextFloat() * 100f;
+            float posY = rng.nextFloat() * 100f;
+            float posZ = rng.nextFloat() * 100f;
+
+            float noise = noiseGen.noise(posX, posY, posZ);
+            if (noise > 0 && noise < 0.00005) {
+                return;
+            }
+        }
+
+        Assert.fail();
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/utilities/NoiseTest.java
+++ b/engine-tests/src/test/java/org/terasology/utilities/NoiseTest.java
@@ -19,12 +19,14 @@ package org.terasology.utilities;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.utilities.procedural.FastNoise;
+import org.terasology.utilities.procedural.Noise3D;
 import org.terasology.utilities.procedural.PerlinNoise;
 import org.terasology.utilities.procedural.SimplexNoise;
 import org.terasology.utilities.random.FastRandom;
 
 /**
- * A simple test for {@link SimplexNoise}
+ * A few tests for different {@link Noise3D} implementations.
  *
  * @author Martin Steiger
  */
@@ -35,53 +37,46 @@ public class NoiseTest {
     @Test
     public void speedTest() {
         int seed = "asdf".hashCode();
-        int warmUp = 10000;
         int count = 1000000;
-        FastRandom pfr = new FastRandom(seed);
-        FastRandom sfr = new FastRandom(seed);
+        int warmUp = 10000;
 
         PerlinNoise pn = new PerlinNoise(seed);
         SimplexNoise sn = new SimplexNoise(seed);
+        FastNoise fn = new FastNoise(seed);
 
-        for (int i = 0; i < warmUp; i++) {
-            float posX = pfr.nextFloat() * 1000f;
-            float posY = pfr.nextFloat() * 1000f;
-            float posZ = pfr.nextFloat() * 1000f;
-
-            pn.noise(posX, posY, posZ);
-        }
-
-        for (int i = 0; i < warmUp; i++) {
-            float posX = sfr.nextFloat() * 1000f;
-            float posY = sfr.nextFloat() * 1000f;
-            float posZ = sfr.nextFloat() * 1000f;
-
-            sn.noise(posX, posY, posZ);
-        }
+        run(pn, warmUp);
+        run(sn, warmUp);
+        run(fn, warmUp);
 
         long start = System.nanoTime();
 
-        for (int i = 0; i < count; i++) {
-            float posX = pfr.nextFloat() * 1000f;
-            float posY = pfr.nextFloat() * 1000f;
-            float posZ = pfr.nextFloat() * 1000f;
-
-            pn.noise(posX, posY, posZ);
-        }
+        run(pn, count);
 
         logger.info("Perlin Noise : " + (System.nanoTime() - start) / 1000000 + "ms.");
 
         start = System.nanoTime();
 
-        for (int i = 0; i < count; i++) {
-            float posX = sfr.nextFloat() * 1000f;
-            float posY = sfr.nextFloat() * 1000f;
-            float posZ = sfr.nextFloat() * 1000f;
-
-            sn.noise(posX, posY, posZ);
-        }
+        run(sn, count);
 
         logger.info("Simplex Noise : " + (System.nanoTime() - start) / 1000000 + "ms.");
 
+        start = System.nanoTime();
+
+        run(fn, count);
+
+        logger.info("Fast Noise : " + (System.nanoTime() - start) / 1000000 + "ms.");
+
+    }
+
+    private void run(Noise3D noise, int iterations) {
+        FastRandom rng = new FastRandom(23479832);
+
+        for (int i = 0; i < iterations; i++) {
+            float posX = rng.nextFloat() * 1000f;
+            float posY = rng.nextFloat() * 1000f;
+            float posZ = rng.nextFloat() * 1000f;
+
+            noise.noise(posX, posY, posZ);
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/procedural/FastNoise.java
+++ b/engine/src/main/java/org/terasology/utilities/procedural/FastNoise.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.utilities.procedural;
+
+import org.terasology.math.TeraMath;
+
+/**
+ * Produces fast, <b>equal-distributed white noise</b> based on two {@link NoiseTable}s.
+ * Using two noise tables gives a noise resolution of 1/65535, which should be sufficient
+ * for most applications.
+ * Noise is created at discrete intervals only, i.e. noise(3.4) == noise(2.6) == noise(2).
+ * @author Martin Steiger
+ */
+public class FastNoise implements Noise2D, Noise3D {
+
+    private final NoiseTable table1;
+    private final NoiseTable table2;
+
+    public FastNoise(long seed) {
+        table1 = new NoiseTable(seed + 0);
+        table2 = new NoiseTable(seed + 1);
+    }
+
+    /**
+     * Coordinates will be rounded to the closest integer value.
+     * @return equal-distributed white noise in the range [0..1] at a resolution of 0.000015
+     */
+    @Override
+    public float noise(float x, float y, float z) {
+        int ix = TeraMath.floorToInt(x + 0.5);
+        int iy = TeraMath.floorToInt(y + 0.5);
+        int iz = TeraMath.floorToInt(z + 0.5);
+
+        int in1 = table1.noise(ix, iy, iz);
+        int in2 = table2.noise(ix, iy, iz);
+        int in = (in1 << 8) | in2;
+
+        return in / 65535.0f;
+    }
+
+    /**
+     * Coordinates will be rounded to the closest integer value.
+     * @return equal-distributed white noise in the range [0..1] at a resolution of 0.000015
+     */
+    @Override
+    public float noise(float x, float y) {
+        int ix = TeraMath.floorToInt(x + 0.5);
+        int iy = TeraMath.floorToInt(y + 0.5);
+
+        int in1 = table1.noise(ix, iy);
+        int in2 = table2.noise(ix, iy);
+        int in = (in1 << 8) | in2;
+
+        return in / 65535.0f;
+    }
+
+}

--- a/engine/src/main/java/org/terasology/utilities/procedural/NoiseTable.java
+++ b/engine/src/main/java/org/terasology/utilities/procedural/NoiseTable.java
@@ -56,20 +56,20 @@ public class NoiseTable {
     }
 
     public int noise(int x) {
-        int xInt = (int) TeraMath.fastFloor(x) & 255;
+        int xInt = x & 255;
         return noisePermutations[xInt];
     }
 
     public int noise(int x, int y) {
-        int xInt = (int) TeraMath.fastFloor(x) & 255;
-        int yInt = (int) TeraMath.fastFloor(y) & 255;
+        int xInt = x & 255;
+        int yInt = y & 255;
         return noisePermutations[noisePermutations[xInt] + yInt];
     }
 
     public int noise(int x, int y, int z) {
-        int xInt = (int) TeraMath.fastFloor(x) & 255;
-        int yInt = (int) TeraMath.fastFloor(y) & 255;
-        int zInt = (int) TeraMath.fastFloor(z) & 255;
+        int xInt = x & 255;
+        int yInt = y & 255;
+        int zInt = z & 255;
         return noisePermutations[noisePermutations[noisePermutations[xInt] + yInt] + zInt];
     }
 }


### PR DESCRIPTION
This PR adds `FastNoise`, a 2D and 3D noise based on two NoiseTables. It
- compatible to the `Noise2D` and `Noise3D` interfaces
- about 2x faster than SimplexNoise and 5x faster than PerlinNoise (see tests)
- produces white noise (equal frequency on all levels)
- normalized (output is always in [0..1])
- equal-distributed (all values have the same probabilities)
- high resolution (values differ in ranges < 0.000015)
- only discrete input values supported :cry: 
- range is only 256 values - noise(256) == noise(0) :cry: 
